### PR TITLE
Don't use dt.combine

### DIFF
--- a/forecast.py
+++ b/forecast.py
@@ -119,8 +119,7 @@ class Forecast(object):
 
         # Get the furthest date in the future we can get a forecast for
         max_forecast_date = dt.now().date() + timedelta(days=MAX_FORECAST_LEN)
-        furthest_date_requested = dt.combine(date_start,
-                                             timedelta(days=forecast_length))
+        furthest_date_requested = date_start + timedelta(days=forecast_length)
 
         # Check to see that the forecast dates requested are not too far into
         # the future


### PR DESCRIPTION
Closes #23, closes #24.

The [`datetime.combine`](https://docs.python.org/2/library/datetime.html#datetime.datetime.combine) function does not take a `timedelta`.

This is confusing users: https://stackoverflow.com/questions/53077389/dialogflow-weather-webhook-connection-error/53088143

(cc @xVir @matthewayne)